### PR TITLE
Remove pinned versions of dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    devise-jwt-cookie (0.5.0)
-      devise-jwt (~> 0.6)
-      dry-auto_inject (~> 0.6)
-      dry-configurable (~> 0.9, < 0.11)
+    devise-jwt-cookie (0.5.1)
+      devise-jwt
+      dry-auto_inject
+      dry-configurable
 
 GEM
   remote: https://rubygems.org/
@@ -51,7 +51,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (9.0.0)
-    bcrypt (3.1.17)
+    bcrypt (3.1.18)
     builder (3.2.4)
     byebug (11.1.3)
     codeclimate-test-reporter (1.0.7)
@@ -65,20 +65,19 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise-jwt (0.8.1)
+    devise-jwt (0.9.0)
       devise (~> 4.0)
-      warden-jwt_auth (~> 0.5)
+      warden-jwt_auth (~> 0.6)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    dry-auto_inject (0.7.0)
+    dry-auto_inject (0.9.0)
       dry-container (>= 0.3.4)
-    dry-configurable (0.9.0)
+    dry-configurable (0.15.0)
       concurrent-ruby (~> 1.0)
-      dry-core (~> 0.4, >= 0.4.7)
-    dry-container (0.7.2)
+      dry-core (~> 0.6)
+    dry-container (0.10.1)
       concurrent-ruby (~> 1.0)
-      dry-configurable (~> 0.1, >= 0.1.3)
-    dry-core (0.6.0)
+    dry-core (0.8.1)
       concurrent-ruby (~> 1.0)
     erubi (1.10.0)
     globalid (1.0.0)
@@ -86,7 +85,7 @@ GEM
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     json (2.6.1)
-    jwt (2.3.0)
+    jwt (2.5.0)
     loofah (2.15.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -180,9 +179,9 @@ GEM
       thread_safe (~> 0.1)
     warden (1.2.9)
       rack (>= 2.0.9)
-    warden-jwt_auth (0.5.0)
-      dry-auto_inject (~> 0.6)
-      dry-configurable (~> 0.9)
+    warden-jwt_auth (0.6.0)
+      dry-auto_inject (~> 0.8)
+      dry-configurable (~> 0.13)
       jwt (~> 2.1)
       warden (~> 1.2)
     websocket-driver (0.7.5)
@@ -205,4 +204,4 @@ DEPENDENCIES
   sqlite3 (~> 1.3)
 
 BUNDLED WITH
-   2.1.4
+   2.3.11

--- a/devise-jwt-cookie.gemspec
+++ b/devise-jwt-cookie.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'devise-jwt', '~> 0.6'
-  spec.add_dependency 'dry-auto_inject', '~> 0.6'
-  spec.add_dependency 'dry-configurable', '~> 0.9', '< 0.11'
+  spec.add_dependency 'devise-jwt'
+  spec.add_dependency 'dry-auto_inject'
+  spec.add_dependency 'dry-configurable'
 
   spec.add_development_dependency "bundler", "> 1"
   spec.add_development_dependency "rake", "~> 12.3"


### PR DESCRIPTION
* Pinned dependency versions causing bundle error with latest devise-jwt